### PR TITLE
Update Go dep version

### DIFF
--- a/deps_versions.bzl
+++ b/deps_versions.bzl
@@ -8,7 +8,7 @@ versions = struct(
     RULES_GO_SHA256 = "278b7ff5a826f3dc10f04feaf0b70d48b68748ccd512d7f98bf442077f043fe3",
 
     # go
-    GO_VERSION = "1.21.0",
+    GO_VERSION = "1.22.5",
 
     # rules_rust
     RULES_RUST_VERSION = "0.40.0",


### PR DESCRIPTION
I got the following error setting up a new project:
```
failed to fetch com_github_bazelbuild_rules_go: fetch_repo: github.com/bazelbuild/rules_go@v0.44.0 requires go >= 1.21.1 (running go 1.21.0)
```

Updated the dep and ran tests:
```
» bazel test //generation_tests/...
INFO: Analyzed 28 targets (561 packages loaded, 24547 targets configured).
INFO: Found 1 target and 27 test targets...
INFO: Elapsed time: 166.348s, Critical Path: 117.34s
INFO: 1012 processes: 303 internal, 709 linux-sandbox.
INFO: Build completed successfully, 1012 total actions
//generation_tests:all_kinds                                             PASSED in 0.1s
//generation_tests:cargo/all_kinds                                       PASSED in 0.1s
//generation_tests:cargo/basic                                           PASSED in 0.1s
//generation_tests:cargo/crate_tests                                     PASSED in 0.1s
//generation_tests:cargo/dependencies                                    PASSED in 0.1s
//generation_tests:cargo/mixed_modes                                     PASSED in 0.1s
//generation_tests:cargo/multi_package_workspace                         PASSED in 0.1s
//generation_tests:cargo/nested_modules                                  PASSED in 0.1s
//generation_tests:cargo/update_rule                                     PASSED in 0.1s
//generation_tests:crate_tests                                           PASSED in 0.1s
//generation_tests:default_kind_inference                                PASSED in 0.1s
//generation_tests:duplicate_crate_names                                 PASSED in 0.1s
//generation_tests:existing_rule                                         PASSED in 0.1s
//generation_tests:ignore                                                PASSED in 0.1s
//generation_tests:keep_comments                                         PASSED in 0.1s
//generation_tests:map_kind                                              PASSED in 0.1s
//generation_tests:missing_deps                                          PASSED in 0.1s
//generation_tests:packages                                              PASSED in 0.1s
//generation_tests:parse_error                                           PASSED in 0.1s
//generation_tests:proc_macro                                            PASSED in 0.1s
//generation_tests:simple                                                PASSED in 0.1s
//generation_tests:source_grouping                                       PASSED in 0.1s
//generation_tests/crate_universe:standard_bazel_lock                    PASSED in 0.1s
//generation_tests/crate_universe:standard_cargo_lock                    PASSED in 0.1s
//generation_tests/crate_universe:standard_hyphenated_crate_names        PASSED in 0.1s
//generation_tests/crate_universe:standard_unused_crates                 PASSED in 0.1s
//generation_tests/crate_universe:vendored                               PASSED in 0.1s

Executed 27 out of 27 tests: 27 tests pass.
There were tests whose specified size is too big. Use the --test_verbose_timeout_warnings command line option to see which ones these are.
sapphire :: ~/Code/gazelle_rust » bazel test //...                 
INFO: Analyzed 47 targets (12 packages loaded, 343 targets configured).
INFO: Found 18 targets and 29 test targets...
INFO: Elapsed time: 123.680s, Critical Path: 112.79s
INFO: 255 processes: 23 internal, 232 linux-sandbox.
INFO: Build completed successfully, 255 total actions
//generation_tests:all_kinds                                    (cached) PASSED in 0.1s
//generation_tests:cargo/all_kinds                              (cached) PASSED in 0.1s
//generation_tests:cargo/basic                                  (cached) PASSED in 0.1s
//generation_tests:cargo/crate_tests                            (cached) PASSED in 0.1s
//generation_tests:cargo/dependencies                           (cached) PASSED in 0.1s
//generation_tests:cargo/mixed_modes                            (cached) PASSED in 0.1s
//generation_tests:cargo/multi_package_workspace                (cached) PASSED in 0.1s
//generation_tests:cargo/nested_modules                         (cached) PASSED in 0.1s
//generation_tests:cargo/update_rule                            (cached) PASSED in 0.1s
//generation_tests:crate_tests                                  (cached) PASSED in 0.1s
//generation_tests:default_kind_inference                       (cached) PASSED in 0.1s
//generation_tests:duplicate_crate_names                        (cached) PASSED in 0.1s
//generation_tests:existing_rule                                (cached) PASSED in 0.1s
//generation_tests:ignore                                       (cached) PASSED in 0.1s
//generation_tests:keep_comments                                (cached) PASSED in 0.1s
//generation_tests:map_kind                                     (cached) PASSED in 0.1s
//generation_tests:missing_deps                                 (cached) PASSED in 0.1s
//generation_tests:packages                                     (cached) PASSED in 0.1s
//generation_tests:parse_error                                  (cached) PASSED in 0.1s
//generation_tests:proc_macro                                   (cached) PASSED in 0.1s
//generation_tests:simple                                       (cached) PASSED in 0.1s
//generation_tests:source_grouping                              (cached) PASSED in 0.1s
//generation_tests/crate_universe:standard_bazel_lock           (cached) PASSED in 0.1s
//generation_tests/crate_universe:standard_cargo_lock           (cached) PASSED in 0.1s
//generation_tests/crate_universe:standard_hyphenated_crate_names (cached) PASSED in 0.1s
//generation_tests/crate_universe:standard_unused_crates        (cached) PASSED in 0.1s
//generation_tests/crate_universe:vendored                      (cached) PASSED in 0.1s
//rust_language:gofmt_test                                               PASSED in 0.3s
//rust_parser/tests:parse_test                                           PASSED in 0.0s
```

Please let me know if I missed something.