### PR TITLE
Support multi-version crate universe dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,17 @@ adding a file to `srcs` for an existing target, and gazelle will respect that ex
 gazelle\_rust does not currently support sources in subdirectories, and will always place targets
 into build files adjacent to the sources that they correspond to.
 
+## Generation from Cargo.toml files
+
+It is possible to instruct gazelle\_rust to generate `BUILD.bazel` files next to existing
+`Cargo.toml` files, which may be helpful if you would like to keep `Cargo.toml` files around and
+structure your Bazel definitions around them. This mode of operation is enabled by adding the
+following directive:
+
+```py
+# gazelle:rust_mode generate_from_cargo
+```
+
 ## Assigning dependencies
 
 gazelle\_rust parses each source file and identifies any path that looks like an external crate

--- a/generation_tests/cargo/multi_package_workspace_with_cargo_lock/Cargo.lock
+++ b/generation_tests/cargo/multi_package_workspace_with_cargo_lock/Cargo.lock
@@ -5,12 +5,16 @@ version = 4
 [[package]]
 name = "a"
 version = "0.1.0"
+dependencies = [
+ "strum 0.24.1",
+]
 
 [[package]]
 name = "b"
 version = "0.1.0"
 dependencies = [
  "a",
+ "strum 0.27.2",
 ]
 
 [[package]]
@@ -20,3 +24,15 @@ dependencies = [
  "a",
  "b",
 ]
+
+[[package]]
+name = "strum"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"

--- a/generation_tests/cargo/multi_package_workspace_with_cargo_lock/Cargo.toml
+++ b/generation_tests/cargo/multi_package_workspace_with_cargo_lock/Cargo.toml
@@ -5,3 +5,6 @@ members = [
     "b",
     "c",
 ]
+
+[workspace.dependencies]
+strum = "0.27"

--- a/generation_tests/cargo/multi_package_workspace_with_cargo_lock/a/BUILD.out
+++ b/generation_tests/cargo/multi_package_workspace_with_cargo_lock/a/BUILD.out
@@ -6,6 +6,7 @@ rust_library(
     compile_data = ["Cargo.toml"],
     crate_name = "a",
     visibility = ["//visibility:public"],
+    deps = ["@crates//:strum-0.24.1"],
 )
 
 rust_binary(

--- a/generation_tests/cargo/multi_package_workspace_with_cargo_lock/a/Cargo.toml
+++ b/generation_tests/cargo/multi_package_workspace_with_cargo_lock/a/Cargo.toml
@@ -2,3 +2,6 @@
 name = "a"
 version = "0.1.0"
 edition = "2021"
+
+[dependencies]
+strum = "0.24.1"

--- a/generation_tests/cargo/multi_package_workspace_with_cargo_lock/a/src/lib.rs
+++ b/generation_tests/cargo/multi_package_workspace_with_cargo_lock/a/src/lib.rs
@@ -1,1 +1,3 @@
+use strum::ParseError;
+
 fn a() {}

--- a/generation_tests/cargo/multi_package_workspace_with_cargo_lock/b/BUILD.out
+++ b/generation_tests/cargo/multi_package_workspace_with_cargo_lock/b/BUILD.out
@@ -5,5 +5,8 @@ rust_library(
     srcs = ["src/lib.rs"],
     compile_data = ["Cargo.toml"],
     visibility = ["//visibility:public"],
-    deps = ["//a:a_lib"],
+    deps = [
+        "//a:a_lib",
+        "@crates//:strum-0.27.2",
+    ],
 )

--- a/generation_tests/cargo/multi_package_workspace_with_cargo_lock/b/Cargo.toml
+++ b/generation_tests/cargo/multi_package_workspace_with_cargo_lock/b/Cargo.toml
@@ -5,3 +5,4 @@ edition = "2021"
 
 [dependencies]
 a = { path = "../a" }
+strum.workspace = true

--- a/generation_tests/cargo/multi_package_workspace_with_cargo_lock/b/src/lib.rs
+++ b/generation_tests/cargo/multi_package_workspace_with_cargo_lock/b/src/lib.rs
@@ -1,4 +1,5 @@
 use a::a;
+use strum::ParseError;
 
 fn b() {
     a();

--- a/proto/messages.proto
+++ b/proto/messages.proto
@@ -41,10 +41,18 @@ message LockfileCratesRequest {
     }
 }
 
+message PackageDependency {
+    string name = 1;
+    string version = 2;
+}
+
 message Package {
     string name = 1;
     string crate_name = 2;
     bool proc_macro = 3;
+    string version = 4;
+    bool workspace_member = 5;
+    repeated PackageDependency dependencies = 6;
 }
 
 message LockfileCratesResponse {
@@ -62,11 +70,12 @@ message CargoCrateInfo {
 }
 
 message CargoTomlResponse {
-    CargoCrateInfo library = 1;
-    repeated CargoCrateInfo binaries = 2;
-    repeated CargoCrateInfo tests = 3;
-    repeated CargoCrateInfo benches = 4;
-    repeated CargoCrateInfo examples = 5;
-    bool success = 6;
-    string error_msg = 7;
+    string name = 1;
+    CargoCrateInfo library = 2;
+    repeated CargoCrateInfo binaries = 3;
+    repeated CargoCrateInfo tests = 4;
+    repeated CargoCrateInfo benches = 5;
+    repeated CargoCrateInfo examples = 6;
+    bool success = 7;
+    string error_msg = 8;
 }

--- a/rust_parser/main.rs
+++ b/rust_parser/main.rs
@@ -92,6 +92,9 @@ fn handle_cargo_toml_request(
 
     let mut response = CargoTomlResponse::default();
     response.set_success(true);
+    if let Some(package) = manifest.package {
+        response.name = package.name;
+    }
 
     if let Some(lib) = manifest.lib {
         response.set_library(build_crate_info(lib));


### PR DESCRIPTION
This is work in progress, but I am curious about your feedback even before I am done implementing this.

I am adding two new directives:
* `rust_cargo_workspace` (optional), this can be used to specify the workspace manifest `Cargo.toml` file.
* `rust_multiversion_crate` (0 or more instances allowed). This is to indicate that a certain crate has several versions that are all used in the workspace. For example, `@crates//:strum-0.24.1` and `@crates//:strum-0.27.2` could both be used and in that case just specifying `@crates//:strum` is incorrect—a version suffix is needed.

With this change I am trying to address two problems:

* Resolve internal packages correctly in a workspace by looking at workspace dependencies with `{ path = ... }` specified. This would translate to the corresponding label inside the repo rather than in external crates, e.g. `foo = { path = "a/b/c" }` would cause `"foo"` to be resolved to `//a/b/c:foo`.
* The multiversion dependencies will be resolved correctly. For this one needs to be able to collect dependency information from both workspace `Cargo.toml` and individual `Cargo.toml` of workspace members.
* Ideally, since clearly `Cargo.lock` is insufficient for correct inference of unused packages I thought that some of this new information can be used to restore that feature in the case of Cargo lock, but it is not so simple, since now there are unused Crates as the level of a member `Cargo.toml` file. I did not go that far yet, I think this is out of scope for this PR.

The question I am struggling with is that for correct resolution I need the results of `l.parseCargoToml` which happens in `generate.go` and I need it in `Resolve` e.g. for determining the version of a multiversion dependency that is actually used in this crate. I don't want to reparse (would need to locate the corret `Cargo.toml` again I guess), but I haven't found a way to pass this information around correctly. Maybe you have ideas?